### PR TITLE
Make Tools and Modules Explicit

### DIFF
--- a/Example/MudExRichTextEditorExample.csproj
+++ b/Example/MudExRichTextEditorExample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="8.11.0" />
+    <PackageReference Include="MudBlazor" Version="8.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.19" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />

--- a/Example/Pages/EditorBasic.razor
+++ b/Example/Pages/EditorBasic.razor
@@ -1,0 +1,40 @@
+﻿@page "/editor-basic"
+@using MudExRichTextEditor
+@using MudExRichTextEditor.Extensibility
+@using MudExRichTextEditor.Types
+
+<PageTitle>Basic Editor</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Basic Text Editor</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">
+    A basic editor with common text formatting options and lists.
+</MudText>
+
+<MudExRichTextEdit @bind-Value="_content"
+                   Height="400"
+                   Tools="@_tools"
+                   Modules="@_modules"
+                   Placeholder="Write your content...">
+</MudExRichTextEdit>
+
+<MudPaper Class="pa-4 mt-4">
+    <MudText Typo="Typo.h6">HTML Output:</MudText>
+    <pre style="max-height: 200px; overflow: auto;">@_content</pre>
+</MudPaper>
+
+@code {
+    private string _content = "<p>Welcome to the <strong>basic editor</strong>!</p>";
+
+    private QuillTool[] _tools =
+    [
+        QuillTools.Header(group: 1, options: ["", "1", "2", "3"]),
+        QuillTools.Bold(),
+        QuillTools.Italic(),
+        QuillTools.Underline(),
+        QuillTools.Strike(),
+        QuillTools.OrderedList(),
+        QuillTools.BulletList(),
+    ];
+
+    private IQuillModule[] _modules = [];
+}

--- a/Example/Pages/EditorCustom.razor
+++ b/Example/Pages/EditorCustom.razor
@@ -1,0 +1,70 @@
+﻿@page "/editor-custom"
+@using MudExRichTextEditor
+@using MudExRichTextEditor.Types
+@using MudExRichTextEditor.Extensibility
+
+<PageTitle>Custom Editor</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Custom Editor Configuration</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">
+    Build your own custom editor by combining presets with additional tools and modules.
+</MudText>
+
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">This Example:</MudText>
+    <MudText Typo="Typo.body2">
+        Starting from the Standard preset, we've added table support and color tools.
+    </MudText>
+</MudPaper>
+
+<MudExRichTextEdit @bind-Value="_content"
+                   Height="400"
+                   Tools="@_tools"
+                   Modules="@_modules"
+                   AlwaysUseRecommendedModules="false"
+                   Placeholder="Customize your editor exactly how you need it...">
+</MudExRichTextEdit>
+
+<MudPaper Class="pa-4 mt-4">
+    <MudText Typo="Typo.h6">Code Example:</MudText>
+    <MudText Typo="Typo.body2" Class="mt-2">
+        <pre style="background-color: #f5f5f5; padding: 16px; border-radius: 4px;">
+private QuillTool[] _tools = 
+[
+    ..QuillPresets.Standard.Tools,  // Start with standard
+    QuillTools.Color(),              // Add colors
+    QuillTools.Background(),         // Add background colors
+    QuillTools.TableButton(),        // Add tables
+];
+
+private IQuillModule[] _modules = 
+[
+    ..QuillPresets.Standard.Modules, // Standard modules
+    new QuillTableBetterModule(),    // Add table functionality
+];
+        </pre>
+    </MudText>
+</MudPaper>
+
+<MudPaper Class="pa-4 mt-4">
+    <MudText Typo="Typo.h6">HTML Output:</MudText>
+    <pre style="max-height: 200px; overflow: auto;">@_content</pre>
+</MudPaper>
+
+@code {
+    private string _content = "<p>This is a <strong>custom configured</strong> editor.</p>";
+
+    private QuillTool[] _tools =
+    [
+        ..QuillPresets.Standard.Tools,  // Start with standard
+        QuillTools.Color(),              // Add colors
+        QuillTools.Background(),         // Add background colors
+        QuillTools.TableButton(),        // Add tables
+    ];
+
+    private IQuillModule[] _modules =
+    [
+        ..QuillPresets.Standard.Modules, // Standard modules
+        new QuillTableBetterModule(),    // Add table functionality
+    ];
+}

--- a/Example/Pages/EditorFull.razor
+++ b/Example/Pages/EditorFull.razor
@@ -1,0 +1,56 @@
+﻿@page "/editor-full"
+@using MudExRichTextEditor
+@using MudExRichTextEditor.Types
+@using MudExRichTextEditor.Extensibility
+
+<PageTitle>Full Featured Editor</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Full Featured Editor</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">
+    A full-featured editor with all formatting options, tables, image editing, and more.
+</MudText>
+
+<MudExRichTextEdit @bind-Value="_content"
+                   Height="500"
+                   Tools="@_tools"
+                   Modules="@_modules"
+                   Placeholder="Create amazing content with tables and images...">
+</MudExRichTextEdit>
+
+<MudPaper Class="pa-4 mt-4">
+    <MudText Typo="Typo.h6">HTML Output:</MudText>
+    <pre style="max-height: 200px; overflow: auto;">@_content</pre>
+</MudPaper>
+
+@code {
+    private string _content = "<h2>Full Featured Editor</h2><p>Try all the features including <strong>tables</strong>!</p>";
+
+    private QuillTool[] _tools =
+    [
+        QuillTools.Header(group: 1),
+        QuillTools.Bold(),
+        QuillTools.Italic(),
+        QuillTools.Underline(),
+        QuillTools.Strike(),
+        QuillTools.Color(),
+        QuillTools.Background(),
+        QuillTools.OrderedList(),
+        QuillTools.BulletList(),
+        QuillTools.IndentDecrease(),
+        QuillTools.IndentIncrease(),
+        QuillTools.Align(),
+        QuillTools.Blockquote(),
+        QuillTools.CodeBlock(),
+        QuillTools.Link(),
+        QuillTools.Image(),
+        QuillTools.Video(),
+        QuillTools.TableButton(),
+    ];
+
+    private IQuillModule[] _modules =
+    [
+        new QuillTableBetterModule(),
+        new QuillBlotFormatterModule(),
+        new QuillImageCompressorModule(),
+    ];
+}

--- a/Example/Pages/EditorMinimal.razor
+++ b/Example/Pages/EditorMinimal.razor
@@ -1,0 +1,37 @@
+﻿@page "/editor-minimal"
+@using MudExRichTextEditor
+@using MudExRichTextEditor.Extensibility
+@using MudExRichTextEditor.Types
+
+<PageTitle>Minimal Editor</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Minimal Editor</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">
+    A simple editor with only basic text formatting: bold, italic, underline, and strike-through.
+</MudText>
+
+<MudExRichTextEdit @bind-Value="_content"
+                   Height="400"
+                   Tools="@_tools"
+                   Modules="@_modules"
+                   Placeholder="Start typing...">
+</MudExRichTextEdit>
+
+<MudPaper Class="pa-4 mt-4">
+    <MudText Typo="Typo.h6">HTML Output:</MudText>
+    <pre style="max-height: 200px; overflow: auto;">@_content</pre>
+</MudPaper>
+
+@code {
+    private string _content = "<p>This is a <strong>minimal</strong> editor example.</p>";
+
+    private QuillTool[] _tools =
+    [
+        QuillTools.Bold(),
+        QuillTools.Italic(),
+        QuillTools.Underline(),
+        QuillTools.Strike(),
+    ];
+
+    private IQuillModule[] _modules = [];
+}

--- a/Example/Pages/EditorPresets.razor
+++ b/Example/Pages/EditorPresets.razor
@@ -1,0 +1,66 @@
+﻿@page "/editor-presets"
+@using MudExRichTextEditor
+@using MudExRichTextEditor.Extensibility
+@using MudExRichTextEditor.Types
+
+<PageTitle>Editor Presets</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Editor Presets</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">
+    Quick start examples using built-in presets for common scenarios.
+</MudText>
+
+<MudText Typo="Typo.h5" Class="mt-6 mb-2">Minimal Preset</MudText>
+<MudText Typo="Typo.body2" Class="mb-3">
+    Perfect for simple text formatting needs.
+</MudText>
+<MudExRichTextEdit @bind-Value="_minimal"
+                   Height="200"
+                   Tools="@_minimalTools"
+                   Modules="@_minimalModules"
+                   AlwaysUseRecommendedModules="false"
+                   Placeholder="Type here...">
+</MudExRichTextEdit>
+
+<MudDivider Class="my-6" />
+
+<MudText Typo="Typo.h5" Class="mb-2">Standard Preset</MudText>
+<MudText Typo="Typo.body2" Class="mb-3">
+    Great for blog posts, articles, and general content.
+</MudText>
+<MudExRichTextEdit @bind-Value="_standard"
+                   Height="200"
+                   Tools="@_standardTools"
+                   Modules="@_standardModules"
+                   AlwaysUseRecommendedModules="false"
+                   Placeholder="Write your article...">
+</MudExRichTextEdit>
+
+<MudDivider Class="my-6" />
+
+<MudText Typo="Typo.h5" Class="mb-2">Full Preset</MudText>
+<MudText Typo="Typo.body2" Class="mb-3">
+    Everything included - perfect for complex documents with tables and media.
+</MudText>
+<MudExRichTextEdit @bind-Value="_full"
+                   Height="200"
+                   Tools="@_fullTools"
+                   Modules="@_fullModules"
+                   AlwaysUseRecommendedModules="false"
+                   Placeholder="Create rich content...">
+</MudExRichTextEdit>
+
+@code {
+    private string _minimal = "<p>Simple and clean.</p>";
+    private string _standard = "<p>Perfect for most content needs.</p>";
+    private string _full = "<p>All features at your fingertips!</p>";
+
+    private QuillTool[] _minimalTools = QuillPresets.Minimal.Tools;
+    private IQuillModule[] _minimalModules = QuillPresets.Minimal.Modules;
+
+    private QuillTool[] _standardTools = QuillPresets.Standard.Tools;
+    private IQuillModule[] _standardModules = QuillPresets.Standard.Modules;
+
+    private QuillTool[] _fullTools = QuillPresets.Full.Tools;
+    private IQuillModule[] _fullModules = QuillPresets.Full.Modules;
+}

--- a/Example/Pages/EditorStandard.razor
+++ b/Example/Pages/EditorStandard.razor
@@ -1,0 +1,45 @@
+﻿@page "/editor-standard"
+@using MudExRichTextEditor
+@using MudExRichTextEditor.Types
+@using MudExRichTextEditor.Extensibility
+
+<PageTitle>Standard Editor</PageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Standard Editor</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">
+    A standard editor with formatting, lists, links, and image support with automatic compression.
+</MudText>
+
+<MudExRichTextEdit @bind-Value="_content"
+                   Height="400"
+                   Tools="@_tools"
+                   Modules="@_modules"
+                   Placeholder="Create rich content...">
+</MudExRichTextEdit>
+
+<MudPaper Class="pa-4 mt-4">
+    <MudText Typo="Typo.h6">HTML Output:</MudText>
+    <pre style="max-height: 200px; overflow: auto;">@_content</pre>
+</MudPaper>
+
+@code {
+    private string _content = "<p>This editor includes <strong>image compression</strong> and more features.</p>";
+
+    private QuillTool[] _tools =
+    [
+        QuillTools.Header(group: 1, options: ["", "1", "2", "3"]),
+        QuillTools.Bold(),
+        QuillTools.Italic(),
+        QuillTools.Underline(),
+        QuillTools.Strike(),
+        QuillTools.OrderedList(),
+        QuillTools.BulletList(),
+        QuillTools.Link(),
+        QuillTools.Image(),
+    ];
+
+    private IQuillModule[] _modules =
+    [
+        new QuillImageCompressorModule(),
+    ];
+}

--- a/Example/Shared/NavMenu.razor
+++ b/Example/Shared/NavMenu.razor
@@ -2,4 +2,12 @@
     <MudNavLink Href="/" Match="NavLinkMatch.All">Home</MudNavLink>
     <MudNavLink Href="/test" Match="NavLinkMatch.Prefix">Test</MudNavLink>
     <MudNavLink Href="/empty" Match="NavLinkMatch.Prefix">Empty</MudNavLink>
+    <MudNavGroup Title="Editor Examples" Icon="@Icons.Material.Filled.Edit">
+        <MudNavLink Href="/editor-minimal">Minimal</MudNavLink>
+        <MudNavLink Href="/editor-basic">Basic</MudNavLink>
+        <MudNavLink Href="/editor-standard">Standard</MudNavLink>
+        <MudNavLink Href="/editor-full">Full Featured</MudNavLink>
+        <MudNavLink Href="/editor-presets">Presets</MudNavLink>
+        <MudNavLink Href="/editor-custom">Custom</MudNavLink>
+    </MudNavGroup>
 </MudNavMenu>

--- a/MudExRichTextEditor/Extensibility/IQuillModule.cs
+++ b/MudExRichTextEditor/Extensibility/IQuillModule.cs
@@ -48,8 +48,11 @@ public interface IQuillModule : IAsyncDisposable
     /// <returns></returns>
     Task OnCreatedAsync(IJSRuntime jsRuntime, MudExRichTextEdit editor);
 
+    /*
+     * Remove this - modules shouldn't auto-inject tools
     /// <summary>
     /// Extra tools that should be added to the toolbar.
     /// </summary>
     IEnumerable<QuillTool> Tools { get; }
+    */
 }

--- a/MudExRichTextEditor/Extensibility/QuillModule.cs
+++ b/MudExRichTextEditor/Extensibility/QuillModule.cs
@@ -40,7 +40,8 @@ public abstract class QuillModule: IQuillModule
         return OnModuleCreatedAsync(jsRuntime, editor);
     }
 
-    public virtual IEnumerable<QuillTool> Tools => [];
+    // Base class should match the interface - no auto-injection of tools.
+    //public virtual IEnumerable<QuillTool> Tools => [];
 
     protected virtual Task OnModuleCreatedAsync(IJSRuntime jsRuntime, MudExRichTextEdit editor) => Task.CompletedTask;
     protected virtual Task<IJSObjectReference> OnModuleLoadedAsync(IJSRuntime jsRuntime, MudExRichTextEdit editor) => Task.FromResult<IJSObjectReference>(null);

--- a/MudExRichTextEditor/Extensibility/QuillTableBetterModule.cs
+++ b/MudExRichTextEditor/Extensibility/QuillTableBetterModule.cs
@@ -15,9 +15,10 @@ public class QuillTableBetterModule : QuillModule
         "./_content/MudExRichTextEditor/css/quill.table.better.mudblazor.css"
     ];
 
-    public override IEnumerable<QuillTool> Tools => [
-        new(cls: "ql-table-better", group: 7)
-    ];
+    // No auto-injection of tools. Module provides functionality only; button must be added explicitly via Tools parameter.
+    //public override IEnumerable<QuillTool> Tools => [
+    //    new(cls: "ql-table-better", group: 7)
+    //];
 
     public override string JsConfigFunction => $"__g{Id}";
 

--- a/MudExRichTextEditor/MudExRichTextEdit.razor.cs
+++ b/MudExRichTextEditor/MudExRichTextEdit.razor.cs
@@ -49,11 +49,11 @@ public partial class MudExRichTextEdit
     private string[] _preInitParameters;
 
     private bool IsOverwritten(string paramName) => _preInitParameters?.Contains(paramName) == true;
-    
+
     /// <summary>
-    /// Is this is true, the editor will always add the recommended modules to <see cref="Modules"/>
+    /// If this is true, the editor will always add the recommended modules to <see cref="Modules"/>, Explicit is better than implicit. Users should opt-in to extra features, not opt-out.
     /// </summary>
-    [Parameter] public bool AlwaysUseRecommendedModules { get; set; } = true;
+    [Parameter] public bool AlwaysUseRecommendedModules { get; set; } = false;
     [Parameter] public bool UseCultureForSpeechRecognition { get; set; } = true;
 
     [Parameter] public IQuillModule[] Modules { get; set; }
@@ -201,7 +201,7 @@ public partial class MudExRichTextEdit
             }).ToArray();
     }
 
-    private QuillTool[] ActiveTools => Tools.Concat(AllModules.SelectMany(module => module?.Tools ?? []).Where(t => t is not null)).ToArray();
+    private QuillTool[] ActiveTools => Tools ?? [];
 
     [JSInvokable]
     public void OnHeightChanged(double height)

--- a/MudExRichTextEditor/MudExRichTextEdit.razor.cs
+++ b/MudExRichTextEditor/MudExRichTextEdit.razor.cs
@@ -53,6 +53,7 @@ public partial class MudExRichTextEdit
     /// <summary>
     /// If this is true, the editor will always add the recommended modules to <see cref="Modules"/>, Explicit is better than implicit. Users should opt-in to extra features, not opt-out.
     /// </summary>
+    [Obsolete("Use QuillPresets instead for recommended configurations.")]
     [Parameter] public bool AlwaysUseRecommendedModules { get; set; } = false;
     [Parameter] public bool UseCultureForSpeechRecognition { get; set; } = true;
 

--- a/MudExRichTextEditor/Types/QuillPresets.cs
+++ b/MudExRichTextEditor/Types/QuillPresets.cs
@@ -1,0 +1,85 @@
+﻿using MudExRichTextEditor.Extensibility;
+
+namespace MudExRichTextEditor.Types;
+
+/// <summary>
+/// Provides preset configurations for common editor setups.
+/// Use these as starting points or examples for your own configurations.
+/// </summary>
+public static class QuillPresets
+{
+    /// <summary>
+    /// Minimal editor with only basic text formatting (bold, italic, underline, strike)
+    /// </summary>
+    public static class Minimal
+    {
+        public static QuillTool[] Tools =>
+        [
+            QuillTools.Bold(group: 1),
+            QuillTools.Italic(group: 1),
+            QuillTools.Underline(group: 1),
+            QuillTools.Strike(group: 1),
+        ];
+
+        public static IQuillModule[] Modules => [];
+    }
+
+    /// <summary>
+    /// Standard editor with common formatting options and image compression
+    /// </summary>
+    public static class Standard
+    {
+        public static QuillTool[] Tools =>
+        [
+            QuillTools.Header(group: 1, options: ["", "1", "2", "3"]),
+            QuillTools.Bold(group: 2),
+            QuillTools.Italic(group: 2),
+            QuillTools.Underline(group: 2),
+            QuillTools.Strike(group: 2),
+            QuillTools.OrderedList(group: 3),
+            QuillTools.BulletList(group: 3),
+            QuillTools.Link(group: 4),
+            QuillTools.Image(group: 4),
+        ];
+
+        public static IQuillModule[] Modules =>
+        [
+            new QuillImageCompressorModule(),
+        ];
+    }
+
+    /// <summary>
+    /// Full-featured editor with all formatting options, tables, and image editing
+    /// </summary>
+    public static class Full
+    {
+        public static QuillTool[] Tools =>
+        [
+            QuillTools.Header(group: 1),
+            QuillTools.Bold(group: 2),
+            QuillTools.Italic(group: 2),
+            QuillTools.Underline(group: 2),
+            QuillTools.Strike(group: 2),
+            QuillTools.Color(group: 3),
+            QuillTools.Background(group: 3),
+            QuillTools.OrderedList(group: 4),
+            QuillTools.BulletList(group: 4),
+            QuillTools.IndentDecrease(group: 4),
+            QuillTools.IndentIncrease(group: 4),
+            QuillTools.Align(group: 4),
+            QuillTools.Blockquote(group: 5),
+            QuillTools.CodeBlock(group: 5),
+            QuillTools.Link(group: 6),
+            QuillTools.Image(group: 6),
+            QuillTools.Video(group: 6),
+            QuillTools.TableButton(group: 7),
+        ];
+
+        public static IQuillModule[] Modules =>
+        [
+            new QuillTableBetterModule(),
+            new QuillBlotFormatterModule(),
+            new QuillImageCompressorModule(),
+        ];
+    }
+}

--- a/MudExRichTextEditor/Types/Tool.cs
+++ b/MudExRichTextEditor/Types/Tool.cs
@@ -69,3 +69,54 @@ public class QuillTool
         yield return new QuillTool(cls: "ql-video", group: 6);
     }
 }
+
+/// <summary>
+/// Factory methods for creating QuillTool instances for module-specific functionality.
+/// Use these to explicitly add tools that require corresponding modules.
+/// </summary>
+public static class QuillTools
+{
+    // Text Formatting Tools
+    public static QuillTool Bold(int group = 2) => new(cls: "ql-bold", group: group);
+    public static QuillTool Italic(int group = 2) => new(cls: "ql-italic", group: group);
+    public static QuillTool Underline(int group = 2) => new(cls: "ql-underline", group: group);
+    public static QuillTool Strike(int group = 2) => new(cls: "ql-strike", group: group);
+
+    // Header Tools
+    public static QuillTool Header(int group = 1, string[] options = null) =>
+        new(cls: "ql-header", group: group, options: options ?? ["", "1", "2", "3", "4", "5", "6"]);
+
+    // Color Tools
+    public static QuillTool Color(int group = 3, string[] colors = null) =>
+        new(cls: "ql-color", group: group, options: colors ?? []);
+    public static QuillTool Background(int group = 3, string[] colors = null) =>
+        new(cls: "ql-background", group: group, options: colors ?? []);
+
+    // List Tools
+    public static QuillTool OrderedList(int group = 4) => new(cls: "ql-list", value: "ordered", group: group);
+    public static QuillTool BulletList(int group = 4) => new(cls: "ql-list", value: "bullet", group: group);
+
+    // Indent Tools
+    public static QuillTool IndentDecrease(int group = 4) => new(cls: "ql-indent", value: "-1", group: group);
+    public static QuillTool IndentIncrease(int group = 4) => new(cls: "ql-indent", value: "+1", group: group);
+
+    // Alignment Tools
+    public static QuillTool Align(int group = 4, string[] options = null) =>
+        new(cls: "ql-align", group: group, options: options ?? ["", "center", "right", "justify"]);
+
+    // Block Tools
+    public static QuillTool Blockquote(int group = 5) => new(cls: "ql-blockquote", group: group);
+    public static QuillTool CodeBlock(int group = 5) => new(cls: "ql-code-block", group: group);
+
+    // Media Tools
+    public static QuillTool Link(int group = 6) => new(cls: "ql-link", group: group);
+    public static QuillTool Image(int group = 6) => new(cls: "ql-image", group: group);
+    public static QuillTool Video(int group = 6) => new(cls: "ql-video", group: group);
+
+    // Module-specific Tools (require corresponding modules to be added to Modules)
+
+    /// <summary>
+    /// Table tool button - requires QuillTableBetterModule to be added to Modules
+    /// </summary>
+    public static QuillTool TableButton(int group = 7) => new(cls: "ql-table-better", group: group);
+}

--- a/ServerSideExampleDemo/ServerSideExampleDemo.csproj
+++ b/ServerSideExampleDemo/ServerSideExampleDemo.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="8.3.0" />
+    <PackageReference Include="MudBlazor" Version="8.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MudExRichTextEditor\MudExRichTextEditor.csproj" />


### PR DESCRIPTION
# Make Tools and Modules Explicit

## Problem
Users specify 4 tools but get 5+ buttons because modules secretly inject their own buttons.

```razor
<!-- I specify 4 tools -->
<MudExRichTextEdit Tools="@myFourTools" />

<!-- But I get a table button too! Why? -->
```

Not predictable. Not discoverable.

## Solution
- Commented `IQuillModule.Tools` - modules no longer auto-inject buttons
- Changed `AlwaysUseRecommendedModules` default to `false` (opt-in, not opt-out)
- Added `QuillTools` factory methods and `QuillPresets` for easy configuration

## Migration

**Before:**
```razor
<MudExRichTextEdit />
```

**After:**
```razor
<MudExRichTextEdit 
    Tools="@QuillPresets.Standard.Tools"
    Modules="@QuillPresets.Standard.Modules" />
```

Or build custom:
```csharp
private QuillTool[] _tools = [QuillTools.Bold(), QuillTools.TableButton()];
private IQuillModule[] _modules = [new QuillTableBetterModule()];
```

## What Changed
- Core files: Commented `Tools` property from modules
- New: `QuillTools` factory class
- New: `QuillPresets.cs` (Minimal/Standard/Full configurations)
- New: 6 example pages

## Result
Specify 4 tools → get 4 buttons. No surprises.

---

**Note:** `AlwaysUseRecommendedModules` is now obsolete but kept for backward compatibility.